### PR TITLE
Removed GetEntities parameter

### DIFF
--- a/Runtime/PPMaster.cs
+++ b/Runtime/PPMaster.cs
@@ -122,7 +122,7 @@ namespace Planetary {
             return sdk.entities[uuid];
         }
 
-        public List<Entity> GetEntities(string uuid) {
+        public List<Entity> GetEntities() {
             return new List<Entity>(sdk.entities.Values);
         }
 


### PR DESCRIPTION
GetEntities() doesn't need a parameter: https://docs.planetaryprocessing.io/sdks/unity#ppmaster